### PR TITLE
MISC Tweak Jenkinsfile Configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent {
         docker {
-            label "my127ws"
             image 'my127/php:7.2-fpm-stretch-console'
         }
     }


### PR DESCRIPTION
Adjusted the Inviqa Jenkins instance to use my127ws agents by default for docker, this lets us have a cleaner more agnostic Jenkinsfile that could be run on any jenkins instance without tweaking.