### PR TITLE
Report error based on response body

### DIFF
--- a/spec/Inviqa/OneStock/OneStockResponseSpec.php
+++ b/spec/Inviqa/OneStock/OneStockResponseSpec.php
@@ -59,4 +59,18 @@ class OneStockResponseSpec extends ObjectBehavior
         $this->getErrorEntityId()->shouldBe('1');
         $this->getErrorCode()->shouldBe(409);
     }
+
+    function it_is_not_successful_when_response_body_contains_error_code(
+        ResponseInterface $response, StreamInterface $body
+    ) {
+        $response->getStatusCode()->willReturn(200);
+        $body->__toString()->willReturn(json_encode([
+            [
+                "code" => 400,
+                "error" => "invalid id: expected a string",
+            ]
+        ]));
+
+        $this->isSuccess()->shouldReturn(false);
+    }
 }

--- a/src/Inviqa/OneStock/OneStockResponse.php
+++ b/src/Inviqa/OneStock/OneStockResponse.php
@@ -27,13 +27,9 @@ class OneStockResponse
     public function isSuccess(): bool
     {
         try {
-            $body = $this->getResponseBodyAsArray();
-
-            if (is_iterable($body)) {
-                foreach ($body as $item) {
-                    if (isset($item['code']) && !$this->isSuccessfulCode($item['code'])) {
-                        return false;
-                    }
+            foreach ($this->getResponseBodyAsArray() as $item) {
+                if (isset($item['code']) && !$this->isSuccessfulCode($item['code'])) {
+                    return false;
                 }
             }
         } catch (RuntimeException $e) {

--- a/src/Inviqa/OneStock/OneStockResponse.php
+++ b/src/Inviqa/OneStock/OneStockResponse.php
@@ -26,7 +26,21 @@ class OneStockResponse
 
     public function isSuccess(): bool
     {
-        return substr((string) $this->response->getStatusCode(), 0, 1) === '2';
+        try {
+            $body = $this->getResponseBodyAsArray();
+
+            if (is_iterable($body)) {
+                foreach ($body as $item) {
+                    if (isset($item['code']) && !$this->isSuccessfulCode($item['code'])) {
+                        return false;
+                    }
+                }
+            }
+        } catch (RuntimeException $e) {
+            // Not a valid JSON, stop looking for error codes.
+        }
+
+        return $this->isSuccessfulCode((string) $this->response->getStatusCode());
     }
 
     /**
@@ -95,6 +109,11 @@ class OneStockResponse
     public function response(): ResponseInterface
     {
         return $this->response;
+    }
+
+    protected function isSuccessfulCode(string $code): bool
+    {
+        return substr($code, 0, 1) === '2';
     }
 
     private function getResponseBodyAsArray(): array


### PR DESCRIPTION
When the HTTP code is `2xx`, but the response body contains an error code, it's reported as successful.
That's not true. This PR fixes that.

[For example](https://doc.onestock-retail.com/api/#multi_line_items_patch):

### Request
`PATCH /multi/line_items`

### Response
`200 OK`
```json
[
  {
      "code": 400,
      "error": "invalid id: expected a string"
  }
]
```
