### PR TITLE
Make serializer backward compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.4",
         "dantleech/invoke": "^1.0",
-        "symfony/serializer": "^5.0",
-        "symfony/property-access": "^5.0"
+        "symfony/serializer": "^3.4|^4.3|^5.0",
+        "symfony/property-access": "^3.4|^4.3|^5.0"
     },
     "require-dev": {
         "behat/behat": "^3.5",

--- a/spec/Inviqa/OneStock/Normalizer/SkipEmptyPropertyNormalizerSpec.php
+++ b/spec/Inviqa/OneStock/Normalizer/SkipEmptyPropertyNormalizerSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\Inviqa\OneStock\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Serializer\Serializer;
+
+class SkipEmptyPropertyNormalizerSpec extends ObjectBehavior
+{
+    function it_disallows_empty_attributes()
+    {
+        $this->setSerializer(new Serializer());
+        $this->normalize($this->createSubject())->shouldBe(['good' => 123, 'alsoGood' => 'lorem ipsum']);
+    }
+
+    private function createSubject()
+    {
+        return new class {
+            public $good = 123;
+            public $alsoGood = 'lorem ipsum';
+            public $bad = null;
+            public $alsoBad = [];
+        };
+    }
+}

--- a/src/Inviqa/OneStock/Factory/SerializerFactory.php
+++ b/src/Inviqa/OneStock/Factory/SerializerFactory.php
@@ -2,26 +2,14 @@
 
 namespace Inviqa\OneStock\Factory;
 
+use Inviqa\OneStock\Normalizer\SkipEmptyPropertyNormalizer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
-use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
-use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
 class SerializerFactory
 {
     public function createSerializer(): Serializer
     {
-        $arrayCallback = function ($innerObject) {
-            return is_array($innerObject) && empty($innerObject) ? null : $innerObject;
-        };
-
-        return new Serializer([new ObjectNormalizer(null, null, null, null, null, null, [
-            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
-            AbstractNormalizer::CALLBACKS => [
-                'information' => $arrayCallback,
-                'types' => $arrayCallback,
-            ],
-        ])], [new JsonEncoder()]);
+        return new Serializer([new SkipEmptyPropertyNormalizer()], [new JsonEncoder()]);
     }
 }

--- a/src/Inviqa/OneStock/Normalizer/SkipEmptyPropertyNormalizer.php
+++ b/src/Inviqa/OneStock/Normalizer/SkipEmptyPropertyNormalizer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Inviqa\OneStock\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+class SkipEmptyPropertyNormalizer extends ObjectNormalizer
+{
+    protected function isAllowedAttribute($classOrObject, string $attribute, string $format = null, array $context = [])
+    {
+        if (!parent::isAllowedAttribute($classOrObject, $attribute, $format, $context)) {
+            return false;
+        }
+
+        return !in_array($this->getAttributeValue($classOrObject, $attribute), [null, []], true);
+    }
+}


### PR DESCRIPTION
Current implementation requires the [skipping null values](https://symfony.com/doc/current/components/serializer.html#skipping-null-values) feature of the **symfony/serializer** component. That option is available from Symfony 4.3 which makes this library incompatible with older SF version.

This change adds a custom normalizer to remove empty attributes. That makes it compatible starting from Symfony version 3.4.