### PR TITLE
Drop compatibility with Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.4",
         "dantleech/invoke": "^1.0",
-        "symfony/serializer": "^3.4|^4.3|^5.0",
-        "symfony/property-access": "^3.4|^4.3|^5.0"
+        "symfony/serializer": "^3.4|^4.3",
+        "symfony/property-access": "^3.4|^4.3"
     },
     "require-dev": {
         "behat/behat": "^3.5",

--- a/src/Inviqa/OneStock/Normalizer/SkipEmptyPropertyNormalizer.php
+++ b/src/Inviqa/OneStock/Normalizer/SkipEmptyPropertyNormalizer.php
@@ -6,7 +6,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 class SkipEmptyPropertyNormalizer extends ObjectNormalizer
 {
-    protected function isAllowedAttribute($classOrObject, string $attribute, string $format = null, array $context = [])
+    protected function isAllowedAttribute($classOrObject, $attribute, $format = null, array $context = [])
     {
         if (!parent::isAllowedAttribute($classOrObject, $attribute, $format, $context)) {
             return false;


### PR DESCRIPTION
The method signature of `AbstractNormalizer::isAllowedAttribute()` has changed in Symfony 5, therefore it's not compatible with the former version.

This change drops compatibility with Symfony 5 while preserving Symfony 3.x and 4.x.