### PR TITLE
Extend client with short picking line items

### DIFF
--- a/features/bootstrap/Contexts/ApplicationContext.php
+++ b/features/bootstrap/Contexts/ApplicationContext.php
@@ -28,6 +28,14 @@ class ApplicationContext implements Context
     }
 
     /**
+     * @When I send the following short picked items:
+     */
+    public function theFollowingShortPickedItems(PyStringNode $string)
+    {
+        $this->testApplicationProxy->shortPickItems($this->decodeJson($string->getRaw()));
+    }
+
+    /**
      * @When I create the following parcel:
      */
     public function iCreateTheFollowingParcel(PyStringNode $string)

--- a/features/bootstrap/Services/TestApplicationProxy.php
+++ b/features/bootstrap/Services/TestApplicationProxy.php
@@ -39,6 +39,15 @@ class TestApplicationProxy
         }
     }
 
+    public function shortPickItems(array $parameters): void
+    {
+        try {
+            $this->lastApiResponse = $this->application->shortPickItems($parameters);
+        } catch (OneStockException $e) {
+            $this->lastApiException = $e;
+        }
+    }
+
     public function exportOrder(array $orderParameters): void
     {
         try {

--- a/features/domain/export_line_items.feature
+++ b/features/domain/export_line_items.feature
@@ -31,3 +31,20 @@ Feature: Exporting line item updates
             ]
             """
         Then the API should return a successful response
+
+    Scenario: Trigger re-orchestration of line items
+        When I send the following short picked items:
+            """
+            {
+                "order_id": "1234",
+                "line_items": [
+                     {
+                        "date": 1604941750,
+                        "id": "1",
+                        "item_id": "1",
+                        "state": "short_pick"
+                    }
+                ]
+            }
+            """
+        Then the API should return a successful response

--- a/features/fixtures/php-vcr-casettes/onestock_success.yml
+++ b/features/fixtures/php-vcr-casettes/onestock_success.yml
@@ -77,3 +77,30 @@
             Date: 'Thu, 09 Jan 2020 12:30:51 GMT'
             Content-Length: '123'
         body: '{"id":"5d3b09337f6566000130baaa"}'
+
+-
+    request:
+        method: PATCH
+        url: 'https://api-qualif.onestock-retail.com/shortpick_line_items'
+        headers:
+            Host: api-qualif.onestock-retail.com
+            Expect: null
+            Content-Type: null
+            Accept-Encoding: null
+            User-Agent: 'GuzzleHttp/6.5.0 curl/7.67.0 PHP/7.3.12'
+            Auth-User: test-user
+            Auth-Password: test-password
+            Accept: null
+        body: '{"order_id":"1234","line_items":[{"date":1604941750,"id":"1","item_id":"1","state":"short_pick"}]}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Content-Type: application/json
+            Request-Id: 5dfcd5015ae7fc000125c569
+            Vary: Origin
+            Date: 'Fri, 20 Dec 2019 14:04:49 GMT'
+            Content-Length: '65'
+        body: '{"id":"1234"}'

--- a/src/Inviqa/OneStock/Agent/RequestAgent.php
+++ b/src/Inviqa/OneStock/Agent/RequestAgent.php
@@ -5,6 +5,7 @@ namespace Inviqa\OneStock\Agent;
 use DTL\Invoke\Invoke;
 use Inviqa\OneStock\Client\ApiClient;
 use Inviqa\OneStock\LineUpdater\LineItemUpdateRequest;
+use Inviqa\OneStock\LineUpdater\ShortPickRequest;
 use Inviqa\OneStock\OneStockResponse;
 use Inviqa\OneStock\Parcel\ParcelCreateRequest;
 
@@ -44,5 +45,12 @@ final class RequestAgent
         ]);
 
         return $this->apiClient->request('POST', 'parcels', $request);
+    }
+
+    public function shortPickItems(array $parameters): OneStockResponse
+    {
+        $request = Invoke::new(ShortPickRequest::class, $parameters);
+
+        return $this->apiClient->request('PATCH', 'shortpick_line_items', $request);
     }
 }

--- a/src/Inviqa/OneStock/Application.php
+++ b/src/Inviqa/OneStock/Application.php
@@ -45,4 +45,13 @@ class Application
             throw OneStockException::createFromException($e);
         }
     }
+
+    public function shortPickItems(array $parameters): OneStockResponse
+    {
+        try {
+            return $this->requestAgent->shortPickItems($parameters);
+        } catch (Exception $e) {
+            throw OneStockException::createFromException($e);
+        }
+    }
 }

--- a/src/Inviqa/OneStock/Entity/ShortPickedLineItem.php
+++ b/src/Inviqa/OneStock/Entity/ShortPickedLineItem.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Inviqa\OneStock\Entity;
+
+use DateTime;
+use Exception;
+use UnexpectedValueException;
+
+class ShortPickedLineItem
+{
+    public $date;
+
+    public $id;
+
+    public $item_id;
+
+    public $state;
+
+    public function __construct(int $date, string $id, string $item_id, string $state)
+    {
+        $this->setDate($date);
+        $this->id = $id;
+        $this->item_id = $item_id;
+        $this->state = $state;
+    }
+
+    private function setDate(int $date): void
+    {
+        try {
+            new DateTime('@' . $date);
+        } catch (Exception $e) {
+            throw new UnexpectedValueException(sprintf('Date parameter must be a valid timestamp, but got "%s".', $date));
+        }
+
+        $this->date = $date;
+    }
+}

--- a/src/Inviqa/OneStock/Entity/ShortPickedLineItem.php
+++ b/src/Inviqa/OneStock/Entity/ShortPickedLineItem.php
@@ -2,8 +2,7 @@
 
 namespace Inviqa\OneStock\Entity;
 
-use DateTime;
-use Exception;
+use DateTimeImmutable;
 use UnexpectedValueException;
 
 class ShortPickedLineItem
@@ -26,9 +25,7 @@ class ShortPickedLineItem
 
     private function setDate(int $date): void
     {
-        try {
-            new DateTime('@' . $date);
-        } catch (Exception $e) {
+        if (DateTimeImmutable::createFromFormat('U', (string) $date) === false) {
             throw new UnexpectedValueException(sprintf('Date parameter must be a valid timestamp, but got "%s".', $date));
         }
 

--- a/src/Inviqa/OneStock/LineUpdater/ShortPickRequest.php
+++ b/src/Inviqa/OneStock/LineUpdater/ShortPickRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Inviqa\OneStock\LineUpdater;
+
+use DTL\Invoke\Invoke;
+use Inviqa\OneStock\Entity\ShortPickedLineItem;
+
+class ShortPickRequest
+{
+    public $order_id;
+
+    public $line_items;
+
+    public function __construct(string $order_id, array $line_items)
+    {
+        $this->order_id = $order_id;
+        $this->line_items = array_map(function ($item) {
+            return Invoke::new(ShortPickedLineItem::class, $item);
+        }, $line_items);
+    }
+}


### PR DESCRIPTION
Add `Inviqa\OneStock\Application::shortPickItems()` method to be called when lines cannot be picked by the warehouse.

Endpoint: `PATCH /shortpick_line_items`

Request body requirements

![image](https://user-images.githubusercontent.com/596431/98576587-0a2ecc80-22bb-11eb-9be3-aa4e2596b8b5.png)
