### PR TITLE
Add custom authentication option

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -37,7 +37,7 @@ $config = PhpCsFixer\Config::create()
         'no_binary_string' => true,
         'no_extra_blank_lines' => ['tokens' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block']],
         'no_null_property_initialization' => true,
-        'no_short_echo_tag' => true,
+        'echo_tag_syntax' => ['format' => 'long'],
         'no_superfluous_elseif' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,

--- a/features/bootstrap/Services/TestApplicationProxy.php
+++ b/features/bootstrap/Services/TestApplicationProxy.php
@@ -3,6 +3,7 @@
 namespace Services;
 
 use Exception;
+use GuzzleHttp\ClientInterface;
 use Inviqa\OneStock\Application;
 use Inviqa\OneStock\Config;
 use Inviqa\OneStock\OneStockException;
@@ -25,9 +26,9 @@ class TestApplicationProxy
      */
     private $lastApiException;
 
-    public function __construct(Config $config)
+    public function __construct(Config $config, ClientInterface $httpClient = null)
     {
-        $this->application = new Application($config);
+        $this->application = new Application($config, $httpClient);
     }
 
     public function updateLineItems(array $lineItemUpdateParameters): void

--- a/features/bootstrap/Services/TestConfig.php
+++ b/features/bootstrap/Services/TestConfig.php
@@ -52,6 +52,11 @@ class TestConfig implements Config
         $this->extraParameters['error'] = $error;
     }
 
+    public function addExtraParameter(string $name, string $value): void
+    {
+        $this->extraParameters[$name] = $value;
+    }
+
     public function getHttpMock(): HttpMock
     {
         return $this->httpMock;

--- a/features/bootstrap/Services/TraceableHttpClient.php
+++ b/features/bootstrap/Services/TraceableHttpClient.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Services;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+use LogicException;
+use GuzzleHttp\ClientInterface;
+
+class TraceableHttpClient implements ClientInterface
+{
+
+    /**
+     * @var ClientInterface
+     */
+    private $decoratedClient;
+
+    public function __construct(ClientInterface $decoratedClient)
+    {
+        $this->decoratedClient = $decoratedClient;
+    }
+
+    /**
+     * @var RequestInterface
+     */
+    private $lastRequest;
+
+    public function send(RequestInterface $request, array $options = [])
+    {
+        $this->lastRequest = $request;
+
+        return $this->decoratedClient->send($request);
+    }
+
+    public function sendAsync(RequestInterface $request, array $options = [])
+    {
+        $this->createMethodNotImplementedException(__METHOD__);
+    }
+
+    public function request($method, $uri, array $options = [])
+    {
+        $this->createMethodNotImplementedException(__METHOD__);
+    }
+
+    public function requestAsync($method, $uri, array $options = [])
+    {
+        $this->createMethodNotImplementedException(__METHOD__);
+    }
+
+    public function getConfig($option = null)
+    {
+        $this->createMethodNotImplementedException(__METHOD__);
+    }
+
+    private function createMethodNotImplementedException(string $methodName): void
+    {
+        throw new LogicException(sprintf('The method %s has not been implemented yet.', $methodName));
+    }
+
+
+    public function getLastRequest(): RequestInterface
+    {
+        return $this->lastRequest;
+    }
+
+}

--- a/features/domain/authentication.feature
+++ b/features/domain/authentication.feature
@@ -1,0 +1,36 @@
+Feature: Authenticaiton
+
+    Scenario: Use the default authentication required by OneStock
+        When I create the following parcel:
+            """
+            {
+                "id": "1234",
+                "date": 201901090000,
+                "to": "shipped",
+                "order_id": 1234,
+                "line_item_ids": [ 1, 2, 3 ,4 ],
+                "tracking_code": "1234"
+            }
+            """
+        Then the API request should have the headers set:
+            | Auth-Username-Header  | Auth-User      |
+            | Auth-Password-Herader | Auth-Password  |
+
+    Scenario: Use custom authentication required by OneStock
+        Given the following extra parameters configured:
+            | authentication_username_header | Custom-Username-Header |
+            | authentication_password_header | Custom-Password-Header |
+        When I create the following parcel:
+            """
+            {
+                "id": "1234",
+                "date": 201901090000,
+                "to": "shipped",
+                "order_id": 1234,
+                "line_item_ids": [ 1, 2, 3 ,4 ],
+                "tracking_code": "1234"
+            }
+            """
+        Then the API request should have the headers set:
+            | Auth-Username-Header  | Custom-Username-Header    |
+            | Auth-Password-Herader | Custom-Password-Header    |

--- a/features/fixtures/php-vcr-casettes/onestock_success.yml
+++ b/features/fixtures/php-vcr-casettes/onestock_success.yml
@@ -167,3 +167,67 @@
             redirect_time_us: 0
             starttransfer_time_us: 505887
             total_time_us: 505950
+-
+    request:
+        method: POST
+        url: 'https://api-qualif.onestock-retail.com/parcels'
+        headers:
+            Host: api-qualif.onestock-retail.com
+            Expect: ''
+            Content-Type: ''
+            Accept-Encoding: ''
+            User-Agent: 'GuzzleHttp/6.5.5 curl/7.73.0 PHP/7.4.13'
+            Custom-Username-Header: test-user
+            Custom-Password-Header: test-password
+            Accept: ''
+        body: '{"site_id":"s100","parcel":{"id":"1234","date":201901090000,"to":"shipped","order_id":"1234","line_item_ids":[1,2,3,4],"tracking_code":"1234"}}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '400'
+            message: 'Bad Request'
+        headers:
+            Content-Type: application/json
+            Request-Id: 5fd8d99478dcf8000159d2a4
+            Vary: Origin
+            Date: 'Tue, 15 Dec 2020 15:43:16 GMT'
+            Content-Length: '58'
+        body: '{"error":"auth_error","message":"missing token parameter"}'
+        curl_info:
+            url: 'https://api-qualif.onestock-retail.com/parcels'
+            content_type: application/json
+            http_code: 400
+            header_size: 169
+            request_size: 355
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.566846
+            namelookup_time: 0.381316
+            connect_time: 0.419544
+            pretransfer_time: 0.513952
+            size_upload: !!float 143
+            size_download: !!float 58
+            speed_download: !!float 102
+            speed_upload: !!float 252
+            download_content_length: !!float 58
+            upload_content_length: !!float 143
+            starttransfer_time: 0.566796
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 51.38.202.101
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 192.168.1.245
+            local_port: 43842
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 513824
+            connect_time_us: 419544
+            namelookup_time_us: 381316
+            pretransfer_time_us: 513952
+            redirect_time_us: 0
+            starttransfer_time_us: 566796
+            total_time_us: 566846

--- a/spec/Inviqa/OneStock/Client/ApiClientFactorySpec.php
+++ b/spec/Inviqa/OneStock/Client/ApiClientFactorySpec.php
@@ -19,6 +19,7 @@ class ApiClientFactorySpec extends ObjectBehavior
         $config->endpoint()->willReturn('foo');
         $config->username()->willReturn('bar');
         $config->password()->willReturn('pass');
+        $config->extraParameters()->willReturn([]);
 
         $this->createApiClient($config)->shouldHaveType(ApiClient::class);
     }

--- a/spec/Inviqa/OneStock/Client/ApiClientFactorySpec.php
+++ b/spec/Inviqa/OneStock/Client/ApiClientFactorySpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Inviqa\OneStock\Client;
 
+use GuzzleHttp\ClientInterface;
 use Inviqa\OneStock\Client\ApiClient;
 use Inviqa\OneStock\Client\ApiClientFactory;
 use Inviqa\OneStock\Client\HttpClient;
@@ -14,13 +15,13 @@ use Psr\Log\LoggerInterface;
  */
 class ApiClientFactorySpec extends ObjectBehavior
 {
-    function it_creates_a_http_client_when_not_in_test_mode(Config $config)
+    function it_creates_a_http_client_when_not_in_test_mode(Config $config, ClientInterface $httpClient)
     {
         $config->endpoint()->willReturn('foo');
         $config->username()->willReturn('bar');
         $config->password()->willReturn('pass');
         $config->extraParameters()->willReturn([]);
 
-        $this->createApiClient($config)->shouldHaveType(ApiClient::class);
+        $this->createApiClient($config, $httpClient)->shouldHaveType(ApiClient::class);
     }
 }

--- a/spec/Inviqa/OneStock/Client/HttpClientSpec.php
+++ b/spec/Inviqa/OneStock/Client/HttpClientSpec.php
@@ -5,6 +5,7 @@ namespace spec\Inviqa\OneStock\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Inviqa\OneStock\Client\HttpAuthentication;
 use Inviqa\OneStock\Client\HttpClient;
 use Inviqa\OneStock\Entity\Address;
 use Inviqa\OneStock\Entity\Country;
@@ -32,7 +33,7 @@ class HttpClientSpec extends ObjectBehavior
     {
         $this->beConstructedWith(
             $client,
-            ['username' => 'user', 'password' => 'password'],
+            new HttpAuthentication('user', 'password'),
             (new SerializerFactory())->createSerializer()
         );
 

--- a/src/Inviqa/OneStock/Application.php
+++ b/src/Inviqa/OneStock/Application.php
@@ -3,6 +3,9 @@
 namespace Inviqa\OneStock;
 
 use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\RequestOptions;
 use Inviqa\OneStock\Factory\ApiOperationFactory;
 
 class Application
@@ -11,9 +14,16 @@ class Application
 
     private $requestAgent;
 
-    public function __construct(Config $config)
+    public function __construct(Config $config, ClientInterface $httpClient = null)
     {
-        $factory = new ApiOperationFactory($config);
+        if (null === $httpClient) {
+            $httpClient = new Client([
+                'base_uri' => $config->endpoint(),
+                RequestOptions::HTTP_ERRORS => false,
+            ]);
+        }
+
+        $factory = new ApiOperationFactory($config, $httpClient);
 
         $this->orderExporter = $factory->createOrderExporter();
         $this->requestAgent = $factory->createRequestAgent();

--- a/src/Inviqa/OneStock/Client/ApiClientFactory.php
+++ b/src/Inviqa/OneStock/Client/ApiClientFactory.php
@@ -2,14 +2,13 @@
 
 namespace Inviqa\OneStock\Client;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\RequestOptions;
+use GuzzleHttp\ClientInterface;
 use Inviqa\OneStock\Config;
 use Inviqa\OneStock\Factory\SerializerFactory;
 
 class ApiClientFactory
 {
-    public static function createApiClient(Config $config): ApiClient
+    public static function createApiClient(Config $config, ClientInterface $httpClient): ApiClient
     {
         $extraParameters = $config->extraParameters();
         $usernameHeader = $extraParameters['authentication_username_header'] ?? null;
@@ -28,10 +27,7 @@ class ApiClientFactory
             );
 
         return new HttpClient(
-            new Client([
-                'base_uri' => $config->endpoint(),
-                RequestOptions::HTTP_ERRORS => false,
-            ]),
+            $httpClient,
             $authentication,
             (new SerializerFactory())->createSerializer()
         );

--- a/src/Inviqa/OneStock/Client/ApiClientFactory.php
+++ b/src/Inviqa/OneStock/Client/ApiClientFactory.php
@@ -11,15 +11,28 @@ class ApiClientFactory
 {
     public static function createApiClient(Config $config): ApiClient
     {
+        $extraParameters = $config->extraParameters();
+        $usernameHeader = $extraParameters['authentication_username_header'] ?? null;
+        $passwordHeader = $extraParameters['authentication_password_header'] ?? null;
+        $customAuthentication = !empty($usernameHeader) && !empty($passwordHeader);
+        $authentication = $customAuthentication
+            ? new HttpAuthentication(
+                $config->username(),
+                $config->password(),
+                $usernameHeader,
+                $passwordHeader
+            )
+            : new HttpAuthentication(
+                $config->username(),
+                $config->password()
+            );
+
         return new HttpClient(
             new Client([
                 'base_uri' => $config->endpoint(),
                 RequestOptions::HTTP_ERRORS => false,
             ]),
-            [
-                'username' => $config->username(),
-                'password' => $config->password(),
-            ],
+            $authentication,
             (new SerializerFactory())->createSerializer()
         );
     }

--- a/src/Inviqa/OneStock/Client/HttpAuthentication.php
+++ b/src/Inviqa/OneStock/Client/HttpAuthentication.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Inviqa\OneStock\Client;
+
+class HttpAuthentication
+{
+    private $username;
+
+    private $password;
+
+    private $usernameHeader;
+
+    private $passwordHeader;
+
+    public function __construct(
+        string $username,
+        string $password,
+        string $usernameHeader = 'Auth-User',
+        string $passwordHeader = 'Auth-Password'
+    ) {
+        $this->username = $username;
+        $this->password = $password;
+        $this->usernameHeader = $usernameHeader;
+        $this->passwordHeader = $passwordHeader;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function getUsernameHeader(): string
+    {
+        return $this->usernameHeader;
+    }
+
+    public function getPasswordHeader(): string
+    {
+        return $this->passwordHeader;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+}

--- a/src/Inviqa/OneStock/Client/HttpClient.php
+++ b/src/Inviqa/OneStock/Client/HttpClient.php
@@ -19,7 +19,7 @@ class HttpClient implements ApiClient
      */
     private $serializer;
 
-    public function __construct(ClientInterface $client, array $authentication, SerializerInterface $serializer)
+    public function __construct(ClientInterface $client, HttpAuthentication $authentication, SerializerInterface $serializer)
     {
         $this->client = $client;
         $this->authentication = $authentication;
@@ -55,8 +55,8 @@ class HttpClient implements ApiClient
     private function buildHeaders(): array
     {
         return [
-            'Auth-User' => $this->authentication['username'],
-            'Auth-Password' => $this->authentication['password'],
+            $this->authentication->getUsernameHeader() => $this->authentication->getUsername(),
+            $this->authentication->getPasswordHeader() => $this->authentication->getPassword(),
         ];
     }
 

--- a/src/Inviqa/OneStock/Factory/ApiOperationFactory.php
+++ b/src/Inviqa/OneStock/Factory/ApiOperationFactory.php
@@ -2,6 +2,7 @@
 
 namespace Inviqa\OneStock\Factory;
 
+use GuzzleHttp\ClientInterface;
 use Inviqa\OneStock\Agent\RequestAgent;
 use Inviqa\OneStock\Client\ApiClientFactory;
 use Inviqa\OneStock\Config;
@@ -15,10 +16,10 @@ class ApiOperationFactory
 
     private $client;
 
-    public function __construct(Config $config)
+    public function __construct(Config $config, ClientInterface $httpClient)
     {
         $this->config = $config;
-        $this->client = ApiClientFactory::createApiClient($config);
+        $this->client = ApiClientFactory::createApiClient($config, $httpClient);
     }
 
     public function createRequestAgent(): RequestAgent


### PR DESCRIPTION
Add custom authentication options
    
An extra configuration parameters:

  - `authentication_username_header`
  - `authentication_password_header`
    
When these are set, the library sends the username/password to OneStock API using these HTTP headers for authentication.